### PR TITLE
feat(domain): add GetTasksUseCase (observe tasks as Flow)

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/domain/usecase/GetTasksUseCase.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/usecase/GetTasksUseCase.kt
@@ -1,0 +1,18 @@
+package com.nazam.todo_clean.domain.usecase
+
+import com.nazam.todo_clean.domain.model.Task
+import com.nazam.todo_clean.domain.repository.TaskRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Use case : récupérer toutes les tâches.
+ * Respecte SOLID :
+ * - SRP : Une seule responsabilité (récupérer les tâches)
+ * - DIP : Dépend d'une abstraction (TaskRepository interface)
+ * - Pure : Pas de dépendance à des frameworks externes
+ */
+class GetTasksUseCase(
+    private val repository: TaskRepository
+) {
+    operator fun invoke(): Flow<List<Task>> = repository.observeTasks()
+}


### PR DESCRIPTION
What’s new
- Added GetTasksUseCase that exposes a Flow<List<Task>> from TaskRepository.observeTasks()

Why
- Encapsulates read access to tasks in the domain layer (Clean Architecture)