### PR TITLE
feat(domain): add UpdateTaskUseCase

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/domain/usecase/UpdateTaskUseCase.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/usecase/UpdateTaskUseCase.kt
@@ -1,0 +1,16 @@
+package com.nazam.todo_clean.domain.usecase
+
+import com.nazam.todo_clean.domain.model.Task
+import com.nazam.todo_clean.domain.repository.TaskRepository
+
+/**
+ * Use case : mettre à jour une tâche existante.
+ * Il encapsule l'appel au repository pour respecter Clean Architecture.
+ */
+class UpdateTaskUseCase(
+    private val repository: TaskRepository
+) {
+    suspend operator fun invoke(task: Task) {
+        repository.update(task)
+    }
+}


### PR DESCRIPTION
What’s new
- Added UpdateTaskUseCase for updating tasks via TaskRepository

Why
- Encapsulates task update logic inside the domain layer
- Keeps presentation layer decoupled from repository