### PR TITLE
feat(domain): add DeleteTaskUseCase

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/domain/usecase/DeleteTaskUseCase.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/usecase/DeleteTaskUseCase.kt
@@ -1,0 +1,15 @@
+package com.nazam.todo_clean.domain.usecase
+
+import com.nazam.todo_clean.domain.repository.TaskRepository
+
+/**
+ * Use case : supprimer une tâche par son identifiant.
+ * La logique passe uniquement par le repository (Clean Architecture).
+ */
+class DeleteTaskUseCase(
+    private val repository: TaskRepository
+) {
+    suspend operator fun invoke(id: Int) {
+        repository.delete(id)
+    }
+}


### PR DESCRIPTION
What’s new
	•	Added DeleteTaskUseCase in the domain layer
	•	Encapsulates task deletion logic with a simple suspend operator fun invoke(id: Int)
	•	Delegates directly to TaskRepository.delete(id)

Why
	•	Keeps the deletion logic inside the domain layer (Clean Architecture principle)
	•	Ensures the presentation layer interacts only with use cases, not repositories directly

Impact
	•	Prepares the foundation for the presentation layer to handle task deletion
	•	Completes the CRUD use cases in the domain layer (Add, Get, Update, Delete)