### PR TITLE
refactor(domain): fix imports in Task, TaskRepository, and AddTaskUse…

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/domain/model/Task.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/model/Task.kt
@@ -1,4 +1,4 @@
-package com.nazam.todo_clean.domain
+package com.nazam.todo_clean.domain.model
 
 
 data class Task(

--- a/app/src/main/java/com/nazam/todo_clean/domain/repository/TaskRepository.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/repository/TaskRepository.kt
@@ -1,10 +1,7 @@
 package com.nazam.todo_clean.domain.repository
 
-import com.nazam.todo_clean.domain.model.Priority
 import com.nazam.todo_clean.domain.model.Task
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Contrat du dépôt de tâches (pas d'implémentation ici).

--- a/app/src/main/java/com/nazam/todo_clean/domain/usecase/AddTaskUseCase.kt
+++ b/app/src/main/java/com/nazam/todo_clean/domain/usecase/AddTaskUseCase.kt
@@ -2,15 +2,15 @@ package com.nazam.todo_clean.domain.usecase
 
 import com.nazam.todo_clean.domain.model.Task
 import com.nazam.todo_clean.domain.repository.TaskRepository
-import javax.inject.Inject
+
 /**
  * Use case : ajouter une tâche.
  * Simple et pur : il appelle juste le repository.
  */
-class AddTaskUseCase @Inject constructor(
-    private val taskRepository: TaskRepository
+class AddTaskUseCase(
+    private val repository: TaskRepository
 ) {
     suspend operator fun invoke(task: Task): Long {
-        return taskRepository.add(task)
+        return repository.add(task)
     }
 }


### PR DESCRIPTION
What’s new
- Fixed incorrect or redundant imports in Task, TaskRepository, and AddTaskUseCase

Why
- Keeps the domain layer clean and free of unused imports
- No functional change, only refactor