### PR TITLE
feat(data): add TaskMapper (Task <-> TaskEntity)

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/data/mapper/TaskMapper.kt
+++ b/app/src/main/java/com/nazam/todo_clean/data/mapper/TaskMapper.kt
@@ -1,0 +1,37 @@
+package com.nazam.todo_clean.data.mapper
+
+import com.nazam.todo_clean.data.local.entity.TaskEntity
+import com.nazam.todo_clean.domain.model.Priority
+import com.nazam.todo_clean.domain.model.Task
+
+/**
+ * Convertit entre les modèles:
+ * - Domain -> Data (Task -> TaskEntity)
+ * - Data   -> Domain (TaskEntity -> Task)
+ */
+object TaskMapper {
+
+    fun toEntity(task: Task): TaskEntity =
+        TaskEntity(
+            id = task.id,
+            title = task.title,
+            description = task.description,
+            priority = task.priority.name, // enum -> String
+            isDone = task.isDone,
+            createdAt = task.createdAt
+        )
+
+    fun toDomain(entity: TaskEntity): Task =
+        Task(
+            id = entity.id,
+            title = entity.title,
+            description = entity.description,
+            priority = entity.priority.toPrioritySafe(),
+            isDone = entity.isDone,
+            createdAt = entity.createdAt
+        )
+
+    // Sécurise la conversion String -> enum (évite crash si valeur inconnue)
+    private fun String.toPrioritySafe(): Priority =
+        try { Priority.valueOf(this) } catch (_: IllegalArgumentException) { Priority.MEDIUM }
+}


### PR DESCRIPTION
What’s new
- Added TaskMapper to convert between domain Task and data TaskEntity
- Safe enum mapping (String -> Priority) with default MEDIUM

Why
- Keeps mapping logic centralized and simple
- Prepares for repository implementation