### PR TITLE
feat(di): provide Room (DB/Dao), TaskRepositoryImpl, and CRUD use cases

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/di/AppModule.kt
+++ b/app/src/main/java/com/nazam/todo_clean/di/AppModule.kt
@@ -1,13 +1,52 @@
 package com.nazam.todo_clean.di
 
+import android.content.Context
+import androidx.room.Room
+import com.nazam.todo_clean.data.local.dao.TaskDao
+import com.nazam.todo_clean.data.local.db.AppDatabase
+import com.nazam.todo_clean.data.repository.TaskRepositoryImpl
+import com.nazam.todo_clean.domain.repository.TaskRepository
+import com.nazam.todo_clean.domain.usecase.AddTaskUseCase
+import com.nazam.todo_clean.domain.usecase.DeleteTaskUseCase
+import com.nazam.todo_clean.domain.usecase.GetTasksUseCase
+import com.nazam.todo_clean.domain.usecase.UpdateTaskUseCase
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-    // Configuration Hilt uniquement
-    // Ici vous pourrez ajouter vos providers @Provides et @Binds
+    // --- ROOM DATABASE ---
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            "todo.db"
+        )
+            // Pour démarrer simple en dev. (En prod: faire des migrations)
+            .fallbackToDestructiveMigration()
+            .build()
+
+    @Provides
+    fun provideTaskDao(db: AppDatabase): TaskDao = db.taskDao()
+
+    // --- REPOSITORY ---
+    @Provides
+    @Singleton
+    fun provideTaskRepository(
+        taskDao: TaskDao
+    ): TaskRepository = TaskRepositoryImpl(taskDao)
+
+    // --- USE CASES (un par fichier, pas de wrapper) ---
+    @Provides fun provideAddTaskUseCase(repo: TaskRepository) = AddTaskUseCase(repo)
+    @Provides fun provideGetTasksUseCase(repo: TaskRepository) = GetTasksUseCase(repo)
+    @Provides fun provideUpdateTaskUseCase(repo: TaskRepository) = UpdateTaskUseCase(repo)
+    @Provides fun provideDeleteTaskUseCase(repo: TaskRepository) = DeleteTaskUseCase(repo)
 }
 


### PR DESCRIPTION
What’s new
- AppDatabase provided via Room.databaseBuilder("todo.db")
- TaskDao provided from AppDatabase
- TaskRepository bound to TaskRepositoryImpl
- Provided Add/Get/Update/Delete Task use cases (no wrapper)

Why
- Wires data and domain layers through Hilt
- Prepares ViewModels to inject use cases directly

Notes
- Uses fallbackToDestructiveMigration() for simplicity during development