### PR TITLE
feat(presentation): add TaskListScreen (Compose + Hilt viewModel)

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
@@ -1,0 +1,174 @@
+package com.nazam.todo_clean.presentation.feature_task_list
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.nazam.todo_clean.domain.model.Priority
+import com.nazam.todo_clean.domain.model.Task
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TaskListScreen(
+    modifier: Modifier = Modifier,
+    viewModel: TaskListViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Affiche une erreur si nécessaire
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearError()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("My Tasks") }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { /* TODO: navigate to Create/Edit */ }) {
+                Text("+")
+            }
+        }
+    ) { padding ->
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when {
+                uiState.isLoading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                uiState.tasks.isEmpty() -> {
+                    Text(
+                        "Aucune tâche pour le moment",
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(uiState.tasks, key = { it.id }) { task ->
+                            TaskItem(
+                                task = task,
+                                onDelete = { viewModel.onDeleteClicked(task.id) },
+                                onClick = { /* TODO: open details or edit */ }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskItem(
+    task: Task,
+    onDelete: () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(12.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = task.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (task.description.isNotBlank()) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = task.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Spacer(Modifier.height(6.dp))
+                AssistChip(
+                    onClick = {},
+                    label = { Text(task.priority.name) }
+                )
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            TextButton(onClick = onDelete) {
+                Text("Suppr")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TaskItemPreview() {
+    TaskItem(
+        task = Task(
+            id = 1,
+            title = "Réviser Kotlin",
+            description = "Relire coroutines + Flow",
+            priority = Priority.HIGH,
+            isDone = false
+        ),
+        onDelete = {},
+        onClick = {}
+    )
+}


### PR DESCRIPTION
What’s new
- TaskListScreen in Compose with LazyColumn
- Consumes TaskListViewModel via hiltViewModel()
- Displays loading, empty, list and errors (snackbar)
- TaskItem component with delete action

Why
- First UI for the todo list (MVVM + Clean)