### PR TITLE
feat(presentation): wire TaskEditScreen with TaskEditViewModel in NavGraph

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
@@ -1,16 +1,19 @@
 package com.nazam.todo_clean.presentation.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.nazam.todo_clean.presentation.feature_task_edit.TaskEditScreen
+import com.nazam.todo_clean.presentation.feature_task_edit.TaskEditViewModel
 import com.nazam.todo_clean.presentation.feature_task_list.TaskListScreen
 
 object Routes {
     const val TASK_LIST = "task_list"
-    // taskId optionnel pour l’édition (null = création)
     const val TASK_EDIT = "task_edit?taskId={taskId}"
 }
 
@@ -22,27 +25,45 @@ fun AppNavGraph() {
         navController = navController,
         startDestination = Routes.TASK_LIST
     ) {
+        // 1) Liste
         composable(Routes.TASK_LIST) {
             TaskListScreen(
-                // quand on cliquera sur le FAB → aller à l’écran d’édition (création)
-                // On branchera ce lambda quand on aura mis à jour TaskListScreen (prochaine étape si tu veux)
+                onAddClick = {
+                    val noId = -1
+                    navController.navigate("task_edit?taskId=$noId")
+                }
             )
         }
 
-        // Placeholder TEMPORAIRE pour compiler
+        // 2) Édition (un SEUL bloc)
         composable(
             route = Routes.TASK_EDIT,
             arguments = listOf(
                 navArgument("taskId") {
                     type = NavType.IntType
                     defaultValue = -1
-                    nullable = false
                 }
             )
         ) { backStackEntry ->
-            // On mettra TaskEditScreen ici dans la prochaine branche
-            // Pour l’instant, simple texte
-            androidx.compose.material3.Text("Task Edit (à venir)")
+            val taskId = backStackEntry.arguments?.getInt("taskId") ?: -1
+
+            // VM Hilt
+            val vm: TaskEditViewModel = hiltViewModel()
+
+            // Écoute l'état pour quitter si sauvegarde OK
+            val uiState = vm.uiState.collectAsState()
+            if (uiState.value.success) {
+                vm.clearMessages()
+                navController.popBackStack()
+            }
+
+            TaskEditScreen(
+                taskId = taskId,
+                onSave = { title, desc, priority ->
+                    vm.saveTask(taskId, title, desc, priority)
+                },
+                onBack = { navController.popBackStack() }
+            )
         }
     }
 }


### PR DESCRIPTION
…What’s new
- In AppNavGraph, TaskEditScreen is now connected to TaskEditViewModel (Hilt)
- Uses nav argument taskId (-1 = create, >=0 = update)
- On success, pops back to the list screen

Why
- Connects UI form with domain use cases through the ViewModel
- Keeps screen dumb and ViewModel smart (MVVM)