### PR TITLE
feat(presentation): add search bar UI in TaskListScreen

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -30,7 +31,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,8 +51,10 @@ fun TaskListScreen(
     onAddClick: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
-
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // 🔎 état local du champ de recherche
+    var query by remember { mutableStateOf("") }
 
     // Affiche une erreur si nécessaire
     LaunchedEffect(uiState.error) {
@@ -72,20 +77,35 @@ fun TaskListScreen(
             }
         }
     ) { padding ->
-        Box(
+        Column(
             modifier = modifier
                 .fillMaxSize()
                 .padding(padding)
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // 🔎 Barre de recherche
+            OutlinedTextField(
+                value = query,
+                onValueChange = {
+                    query = it
+                    viewModel.onQueryChange(it)   // ← informe le ViewModel
+                },
+                label = { Text("Search") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
             when {
                 uiState.isLoading -> {
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    Box(Modifier.fillMaxSize()) {
+                        CircularProgressIndicator(Modifier.align(Alignment.Center))
+                    }
                 }
                 uiState.tasks.isEmpty() -> {
-                    Text(
-                        "Aucune tâche pour le moment",
-                        modifier = Modifier.align(Alignment.Center)
-                    )
+                    Box(Modifier.fillMaxSize()) {
+                        Text("Aucune tâche pour le moment", Modifier.align(Alignment.Center))
+                    }
                 }
                 else -> {
                     LazyColumn(


### PR DESCRIPTION
What’s new
- Added an OutlinedTextField at the top of TaskListScreen
- Connects the input to TaskListViewModel.onQueryChange()
- Keeps existing UI for tasks list, loading, and empty state

Why
- Provides a simple search bar for filtering tasks
- Completes the presentation part of the search feature (UI side)