### PR TITLE
feat(presentation): add TaskDetailViewModel and wire it in AppNavGraph

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_detail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_detail/TaskDetailViewModel.kt
@@ -1,0 +1,56 @@
+package com.nazam.todo_clean.presentation.feature_task_detail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nazam.todo_clean.domain.model.Task
+import com.nazam.todo_clean.domain.usecase.GetTaskByIdUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * VM pour l’écran de détails.
+ * - Récupère taskId depuis la nav (SavedStateHandle)
+ * - Charge la tâche via GetTaskByIdUseCase
+ */
+@HiltViewModel
+class TaskDetailViewModel @Inject constructor(
+    private val getTaskById: GetTaskByIdUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TaskDetailUiState(isLoading = true))
+    val uiState: StateFlow<TaskDetailUiState> = _uiState
+
+    private val taskId: Int = savedStateHandle.get<Int>("taskId") ?: -1
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.value = TaskDetailUiState(isLoading = true)
+            try {
+                val task = if (taskId >= 0) getTaskById(taskId) else null
+                _uiState.value = TaskDetailUiState(task = task, isLoading = false)
+            } catch (e: Exception) {
+                _uiState.value = TaskDetailUiState(
+                    isLoading = false,
+                    error = e.message ?: "Unknown error"
+                )
+            }
+        }
+    }
+
+    fun retry() = load()
+}
+
+data class TaskDetailUiState(
+    val isLoading: Boolean = false,
+    val task: Task? = null,
+    val error: String? = null
+)

--- a/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
@@ -8,6 +8,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.nazam.todo_clean.presentation.feature_task_detail.TaskDetailScreen
+import com.nazam.todo_clean.presentation.feature_task_detail.TaskDetailViewModel
 import com.nazam.todo_clean.presentation.feature_task_edit.TaskEditScreen
 import com.nazam.todo_clean.presentation.feature_task_edit.TaskEditViewModel
 import com.nazam.todo_clean.presentation.feature_task_list.TaskListScreen
@@ -15,6 +17,7 @@ import com.nazam.todo_clean.presentation.feature_task_list.TaskListScreen
 object Routes {
     const val TASK_LIST = "task_list"
     const val TASK_EDIT = "task_edit?taskId={taskId}"
+    const val TASK_DETAIL = "task_detail?taskId={taskId}"
 }
 
 @Composable
@@ -63,6 +66,24 @@ fun AppNavGraph() {
                     vm.saveTask(taskId, title, desc, priority)
                 },
                 onBack = { navController.popBackStack() }
+            )
+        }
+        composable(
+            route = Routes.TASK_DETAIL,
+            arguments = listOf(
+                navArgument("taskId") {
+                    type = NavType.IntType
+                    defaultValue = -1
+                }
+            )
+        ) {
+            val vm: TaskDetailViewModel = hiltViewModel()
+            val state = vm.uiState.collectAsState()
+
+            TaskDetailScreen(
+                task = state.value.task,
+                onBack = { navController.popBackStack() },
+                onEdit = { id -> navController.navigate("task_edit?taskId=$id") }
             )
         }
     }


### PR DESCRIPTION
What’s new
- Added TaskDetailViewModel (Hilt + SavedStateHandle)
- AppNavGraph: new TASK_DETAIL route and VM wiring
- Passes loaded task to TaskDetailScreen

Why
- Proper MVVM for the detail screen
- Enables detail view from navigation with taskId