### PR TITLE
feat(presentation): open TaskDetail on item click from TaskListScreen

### DIFF
--- a/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/feature_task_list/TaskListScreen.kt
@@ -48,7 +48,8 @@ import com.nazam.todo_clean.domain.model.Task
 fun TaskListScreen(
     modifier: Modifier = Modifier,
     viewModel: TaskListViewModel = hiltViewModel(),
-    onAddClick: () -> Unit = {}
+    onAddClick: () -> Unit = {},
+    onItemClick: (Int) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -117,7 +118,7 @@ fun TaskListScreen(
                             TaskItem(
                                 task = task,
                                 onDelete = { viewModel.onDeleteClicked(task.id) },
-                                onClick = { /* TODO: open details or edit */ }
+                                onClick = { onItemClick(task.id) }
                             )
                         }
                     }

--- a/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/nazam/todo_clean/presentation/navigation/AppNavGraph.kt
@@ -34,6 +34,9 @@ fun AppNavGraph() {
                 onAddClick = {
                     val noId = -1
                     navController.navigate("task_edit?taskId=$noId")
+                },
+                onItemClick = { id ->
+                    navController.navigate("task_detail?taskId=$id")
                 }
             )
         }


### PR DESCRIPTION
What’s new
- TaskListScreen exposes onItemClick(id: Int)
- Navigates to task_detail?taskId={id} from list

Why
- Allows opening the read-only detail screen from the task list